### PR TITLE
Add findMe Service

### DIFF
--- a/pybotvac/robot.py
+++ b/pybotvac/robot.py
@@ -125,6 +125,9 @@ class Robot:
 
     def get_schedule(self):
         return self._message({'reqId': "1", 'cmd': "getSchedule"})
+    
+    def locate(self):
+        return self._message({'reqId': "1", 'cmd': "findMe"})
 
     @property
     def schedule_enabled(self):


### PR DESCRIPTION
Add a service call to locate the botvac.  Useful for Home Assistant `vacuum.locate` feature.   If possible please create another release and I can submit a PR to HA and bring in this functionality.