### PR TITLE
Added support for spot cleaning

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Currently the following methods are available in the Robot class:
 
 * get_robot_state()
 * start_cleaning()
+* start_spot_cleaning()
 * pause_cleaning()
 * stop_cleaning()
 * send_to_base()

--- a/pybotvac/robot.py
+++ b/pybotvac/robot.py
@@ -69,7 +69,7 @@ class Robot:
         #Default to using the persistent map if we support basic-3.
         if category is None:
             category = 4 if self.service_version == 'basic-3' else 2
-        
+
         if self.service_version == 'basic-1':
             json = {'reqId': "1",
                     'cmd': "startCleaning",
@@ -103,7 +103,48 @@ class Robot:
                         'modifier': 1,
                         "navigationMode": navigation_mode}
                     }
+
+        return self._message(json)
         
+    def start_spot_cleaning(self, spot_width=400, spot_height=400):
+        # Spot cleaning if applicable to version
+        # spot_width: spot width in cm
+        # spot_height: spot height in cm
+
+        if self.service_version == 'basic-1':
+            json = {'reqId': "1",
+                    'cmd': "startCleaning",
+                    'params': {
+                        'category': 3,
+                        'mode': 1,
+                        'modifier': 1,
+                        'spotWidth': spot_width,
+                        'spotHeight': spot_height}
+                    }
+        elif self.service_version == 'basic-3':
+            json = {'reqId': "1",
+                    'cmd': "startCleaning",
+                    'params': {
+                        'category': 3,
+                        'spotWidth': spot_width,
+                        'spotHeight': spot_height}
+                    }
+        elif self.service_version == 'minimal-2':
+            json = {'reqId': "1",
+                    'cmd': "startCleaning",
+                    'params': {
+                        'category': 3,
+                        'modifier': 1,
+                        "navigationMode": 1}
+                    }
+        else:   # self.service_version == 'micro-2'
+            json = {'reqId': "1",
+                    'cmd': "startCleaning",
+                    'params': {
+                        'category': 3,
+                        "navigationMode": 1}
+                    }
+
         return self._message(json)
 
     def pause_cleaning(self):
@@ -129,7 +170,7 @@ class Robot:
 
     def get_schedule(self):
         return self._message({'reqId': "1", 'cmd': "getSchedule"})
-    
+
     def locate(self):
         return self._message({'reqId': "1", 'cmd': "findMe"})
 


### PR DESCRIPTION
I have an obscure house and have a big usecase for spot cleaning from the docking automated by home assistant.

I added spot cleaning support in accordance with the API at https://developers.neatorobotics.com/api/robot-remote-protocol/spotcleaning.

The API is very similar to the start_cleaning(), but with category=3. But there are so many additions and removals that I created a similar function for readability, and ease of comparing with the reference API published by Neato.

Tested on Botvac Connected (the only version I own).

When support for spot cleaning end up in HA, I will update the HA component accordingly.