### PR TITLE
Support D7 on Firmware 4.3.1

### DIFF
--- a/pybotvac/robot.py
+++ b/pybotvac/robot.py
@@ -8,7 +8,7 @@ import re
 # Disable warning due to SubjectAltNameWarning in certificate
 requests.packages.urllib3.disable_warnings()
 
-SUPPORTED_SERVICES = ['basic-1', 'minimal-2', 'basic-2', 'basic-3']
+SUPPORTED_SERVICES = ['basic-1', 'minimal-2', 'basic-2', 'basic-3', 'basic-4']
 
 
 class UnsupportedDevice(Exception):

--- a/pybotvac/robot.py
+++ b/pybotvac/robot.py
@@ -78,7 +78,7 @@ class Robot:
                         'mode': mode,
                         'modifier': 1}
                     }
-        elif self.service_version == 'basic-3':
+        elif self.service_version == 'basic-3' or 'basic-4':
             json = {'reqId': "1",
                     'cmd': "startCleaning",
                     'params': {


### PR DESCRIPTION
Today my D7's received a firmware update to 4.3.1 which adds zoned cleaning.  It appears that the robots house cleaning service name has changed slightly to `basic-4`, this PR ensures that the library can continue to work and load in Home Assistant.

Error user see's when they attempt to get robot data before this PR:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/pi/home-assistant/lib/python3.6/site-packages/pybotvac/account.py", line 64, in robots
    self.refresh_robots()
  File "/home/pi/home-assistant/lib/python3.6/site-packages/pybotvac/account.py", line 112, in refresh_robots
    endpoint=robot['nucleo_url']))
  File "/home/pi/home-assistant/lib/python3.6/site-packages/pybotvac/robot.py", line 42, in __init__
    raise UnsupportedDevice("Version " + self.service_version + " of service houseCleaning is not known")
pybotvac.robot.UnsupportedDevice: Version basic-4 of service houseCleaning is not known
```

Neato has added zoned cleaning so I am going to attempt and see if I can figure out how to use it with the library, unfortunately developer documentation has not been updated yet.  I will create a separate PR for this :)

Here is the new state output:


{'version': 1, 'reqId': '1', 'result': 'ok', 'data': {}, 'error': None, 'alert': None, 'state': 1, 'action': 0, 'cleaning': {'category': 0, 'mode': 1, 'modifier': 1, 'navigationMode': 1, 'spotWidth': 0, 'spotHeight': 0}, 'details': {'isCharging': False, 'isDocked': True, 'isScheduleEnabled': False, 'dockHasBeenSeen': False, 'charge': 100}, 'availableCommands': {'start': True, 'stop': False, 'pause': False, 'resume': False, 'goToBase': False}, 'availableServices': {'findMe': 'basic-1', 'generalInfo': 'basic-1', 'houseCleaning': 'basic-4', 'IECTest': 'advanced-1', 'logCopy': 'basic-1', 'manualCleaning': 'basic-1', 'maps': 'basic-2', 'preferences': 'basic-1', 'schedule': 'basic-2', 'softwareUpdate': 'basic-1', 'spotCleaning': 'basic-3', 'wifi': 'basic-1'}, 'meta': {'modelName': 'BotVacD7Connected', 'firmware': '4.3.1-180'}}
