### PR TITLE
Zone cleaning

### DIFF
--- a/pybotvac/account.py
+++ b/pybotvac/account.py
@@ -31,6 +31,7 @@ class Account:
         self._maps = {}
         self._headers = {'Accept': 'application/vnd.neato.nucleo.v1'}
         self._login(email, password)
+        self._persistent_maps = {}
 
     def _login(self, email, password):
         """
@@ -50,7 +51,8 @@ class Account:
         response.raise_for_status()
         access_token = response.json()['access_token']
 
-        self._headers['Authorization'] = 'Token token=%s' % access_token
+        self.access_token = access_token
+        self._headers['Authorization'] = 'Token token=%s' % self.access_token
 
     @property
     def robots(self):
@@ -106,7 +108,8 @@ class Account:
                                    serial=robot['serial'],
                                    secret=robot['secret_key'],
                                    traits=robot['traits'],
-                                   endpoint=robot['nucleo_url']))
+                                   endpoint=robot['nucleo_url'],
+                                   access_token=self.access_token,))
 
     @staticmethod
     def get_map_image(url, dest_path=None):
@@ -127,3 +130,12 @@ class Account:
                 shutil.copyfileobj(image.raw, data)
 
         return image.raw
+
+    @property
+    def persistent_maps(self):
+        """
+        Return set of persistent maps for logged in account.
+
+        :return:
+        """
+        return {robot.serial:robot.persistent_maps for robot in self.robots}

--- a/pybotvac/robot.py
+++ b/pybotvac/robot.py
@@ -69,11 +69,12 @@ class Robot:
         response.raise_for_status()
         return response
 
-    def start_cleaning(self, mode=2, navigation_mode=1, category=None):
-        # mode & naivigation_mode used if applicable to service version
+    def start_cleaning(self, mode=2, navigation_mode=1, category=None, boundary_id=None):
+        # mode & navigation_mode used if applicable to service version
         # mode: 1 eco, 2 turbo
         # navigation_mode: 1 normal, 2 extra care, 3 deep
         # category: 2 non-persistent map, 4 persistent map
+        # boundary_id: the id of the zone to clean
 
         #Default to using the persistent map if we support basic-3.
         if category is None:
@@ -96,6 +97,8 @@ class Robot:
                         'modifier': 1,
                         "navigationMode": navigation_mode}
                     }
+            if boundary_id:
+                json['params']['boundaryId'] = boundary_id
         elif self.service_version == 'minimal-2':
             json = {'reqId': "1",
                     'cmd': "startCleaning",


### PR DESCRIPTION
This adds support for zone cleaning. The list of boundary ids can be obtained by calling `get_map_boundaries`.

Depends on #32 

Fixes #31 