### PR TITLE
Offline devices do not throw an exception

### DIFF
--- a/pybotvac/account.py
+++ b/pybotvac/account.py
@@ -110,7 +110,7 @@ class Account:
                                        traits=robot['traits'],
                                        endpoint=robot['nucleo_url']))
             except requests.exceptions.HTTPError:
-                print ("Your '%s' robot is offline.", robot['name'])
+                print ("Your '{}' robot is offline.".format(robot['name']))
                 continue
 
         self.refresh_persistent_maps()

--- a/pybotvac/account.py
+++ b/pybotvac/account.py
@@ -103,11 +103,15 @@ class Account:
             if robot['mac_address'] is None:
                 continue    # Ignore robots without mac-address
 
-            self._robots.add(Robot(name=robot['name'],
-                                   serial=robot['serial'],
-                                   secret=robot['secret_key'],
-                                   traits=robot['traits'],
-                                   endpoint=robot['nucleo_url']))
+            try:
+                self._robots.add(Robot(name=robot['name'],
+                                       serial=robot['serial'],
+                                       secret=robot['secret_key'],
+                                       traits=robot['traits'],
+                                       endpoint=robot['nucleo_url']))
+            except requests.exceptions.HTTPError:
+                print ("Your '%s' robot is offline.", robot['name'])
+                continue
 
         self.refresh_persistent_maps()
         for robot in self._robots:
@@ -154,6 +158,6 @@ class Account:
             resp2 = (requests.get(urljoin(
                 self.ENDPOINT,
                 'users/me/robots/{}/persistent_maps'.format(robot.serial)),
-                                  headers=self._headers))
+                headers=self._headers))
             resp2.raise_for_status()
             self._persistent_maps.update({robot.serial: resp2.json()})


### PR DESCRIPTION
From HA, if your vacuum is offline while HA is started, the complete platform setup fails.
This PR fixes this issue.

The error you'd get is:
`requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://nucleo.neatocloud.com/vendors/neato/robots/XXXXXXX-XXXXX/messages`