### PR TITLE
Avoid missing locale

### DIFF
--- a/pybotvac/robot.py
+++ b/pybotvac/robot.py
@@ -43,8 +43,7 @@ class Robot:
         self._headers = {'Accept': 'application/vnd.neato.nucleo.v1'}
 
         if self.service_version not in SUPPORTED_SERVICES:
-            raise UnsupportedDevice(
-                "Version " + self.service_version + " of service houseCleaning is not known")
+            raise UnsupportedDevice("Version " + self.service_version + " of service houseCleaning is not known")
 
     def __str__(self):
         return "Name: %s, Serial: %s, Secret: %s Traits: %s" % (self.name, self.serial, self.secret, self.traits)
@@ -74,8 +73,7 @@ class Robot:
 
         # Default to using the persistent map if we support basic-3 or basic-4.
         if category is None:
-            category = 4 if self.service_version in [
-                'basic-3', 'basic-4'] and self.has_persistent_maps else 2
+            category = 4 if self.service_version in ['basic-3', 'basic-4'] and self.has_persistent_maps else 2
 
         if self.service_version == 'basic-1':
             json = {'reqId': "1",
@@ -247,8 +245,7 @@ class Auth(requests.auth.AuthBase):
 
         try:
             # Attempt to decode request.body (assume bytes received)
-            msg = '\n'.join([self.serial.lower(), date,
-                             request.body.decode('utf8')])
+            msg = '\n'.join([self.serial.lower(), date, request.body.decode('utf8')])
         except AttributeError:
             # Decode failed, assume request.body is already type str
             msg = '\n'.join([self.serial.lower(), date, request.body])

--- a/pybotvac/robot.py
+++ b/pybotvac/robot.py
@@ -1,10 +1,9 @@
 import hashlib
 import hmac
-import locale
 import os.path
 import re
 import requests
-import time
+from datetime import datetime
 
 # Disable warning due to SubjectAltNameWarning in certificate
 requests.packages.urllib3.disable_warnings()
@@ -44,7 +43,8 @@ class Robot:
         self._headers = {'Accept': 'application/vnd.neato.nucleo.v1'}
 
         if self.service_version not in SUPPORTED_SERVICES:
-            raise UnsupportedDevice("Version " + self.service_version + " of service houseCleaning is not known")
+            raise UnsupportedDevice(
+                "Version " + self.service_version + " of service houseCleaning is not known")
 
     def __str__(self):
         return "Name: %s, Serial: %s, Secret: %s Traits: %s" % (self.name, self.serial, self.secret, self.traits)
@@ -74,7 +74,8 @@ class Robot:
 
         # Default to using the persistent map if we support basic-3 or basic-4.
         if category is None:
-            category = 4 if self.service_version in ['basic-3', 'basic-4'] and self.has_persistent_maps else 2
+            category = 4 if self.service_version in [
+                'basic-3', 'basic-4'] and self.has_persistent_maps else 2
 
         if self.service_version == 'basic-1':
             json = {'reqId': "1",
@@ -123,7 +124,7 @@ class Robot:
             return self._message(json)
 
         return response
-        
+
     def start_spot_cleaning(self, spot_width=400, spot_height=400):
         # Spot cleaning if applicable to version
         # spot_width: spot width in cm
@@ -191,19 +192,19 @@ class Robot:
 
     def locate(self):
         return self._message({'reqId': "1", 'cmd': "findMe"})
-    
+
     def get_general_info(self):
         return self._message({'reqId': "1", 'cmd': "getGeneralInfo"})
-    
+
     def get_local_stats(self):
         return self._message({'reqId': "1", 'cmd': "getLocalStats"})
-    
+
     def get_preferences(self):
         return self._message({'reqId': "1", 'cmd': "getPreferences"})
-    
+
     def get_map_boundaries(self, map_id=None):
         return self._message({'reqId': "1", 'cmd': "getMapBoundaries", 'params': {'mapId': map_id}})
-    
+
     def get_robot_info(self):
         return self._message({'reqId': "1", 'cmd': "getRobotInfo"})
 
@@ -241,16 +242,13 @@ class Auth(requests.auth.AuthBase):
     def __call__(self, request):
         # Due to https://github.com/stianaske/pybotvac/issues/30
         # Neato expects and supports authentication header ONLY for en_US
-        saved_locale = locale.getlocale(locale.LC_TIME)
-        locale.setlocale(locale.LC_TIME, 'en_US.utf8')
-        
-        date = time.strftime('%a, %d %b %Y %H:%M:%S', time.gmtime()) + ' GMT'
-
-        locale.setlocale(locale.LC_TIME, saved_locale)
+        dt = datetime.utcnow()
+        date = dt.strftime('%a, %d %b %Y %H:%M:%S GMT')
 
         try:
             # Attempt to decode request.body (assume bytes received)
-            msg = '\n'.join([self.serial.lower(), date, request.body.decode('utf8')])
+            msg = '\n'.join([self.serial.lower(), date,
+                             request.body.decode('utf8')])
         except AttributeError:
             # Decode failed, assume request.body is already type str
             msg = '\n'.join([self.serial.lower(), date, request.body])


### PR DESCRIPTION
The locale en_US.UTF-8 is not available in some environments (e.g. some docker containers). 

This PR takes the time from datetime.utcnow(), which is independent of the operating system and its locales. Please correct me, if I'm wrong.

I've tested this on a german setting. Please test this in other environments.

Fixes https://github.com/home-assistant/home-assistant/issues/25773