### PR TITLE
Fix no floorplan available

### DIFF
--- a/pybotvac/robot.py
+++ b/pybotvac/robot.py
@@ -12,6 +12,7 @@ from .neato import Neato    # For default Vendor argument
 requests.packages.urllib3.disable_warnings()
 
 SUPPORTED_SERVICES = ['basic-1', 'minimal-2', 'basic-2', 'basic-3', 'basic-4']
+ALERTS_FLOORPLAN = ['nav_floorplan_load_fail', 'nav_floorplan_localization_fail', 'nav_floorplan_not_created']
 
 
 class UnsupportedDevice(Exception):
@@ -120,7 +121,9 @@ class Robot:
         response_dict = response.json()
 
         # Fall back to category 2 if we tried and failed with category 4
-        if category == 4 and 'alert' in response_dict and response_dict['alert'] == 'nav_floorplan_load_fail':
+        if (category == 4 and
+                ('alert' in response_dict and response_dict['alert'] in ALERTS_FLOORPLAN) or
+                ('result' in response_dict and response_dict['result'] == 'not_on_charge_base')):
             json['params']['category'] = 2
             return self._message(json)
 


### PR DESCRIPTION
Closes: #41 
Closes: #50 

According to the [documentation](https://developers.neatorobotics.com/api/robot-remote-protocol/request-response-formats) there are different issues preventing a robot from start cleaning. We already ignore the warning `nav_floorplan_load_fail`. From now on we also ignore some other similar warnings about a missing floorplan.