### PR TITLE
Avoid missing locale

### DIFF
--- a/pybotvac/robot.py
+++ b/pybotvac/robot.py
@@ -2,6 +2,7 @@ import hashlib
 import hmac
 import os.path
 import re
+import urllib3
 import requests
 from datetime import datetime
 from babel.dates import format_datetime
@@ -9,7 +10,7 @@ from babel.dates import format_datetime
 from .neato import Neato    # For default Vendor argument
 
 # Disable warning due to SubjectAltNameWarning in certificate
-requests.packages.urllib3.disable_warnings()
+urllib3.disable_warnings(urllib3.exceptions.SubjectAltNameWarning)
 
 SUPPORTED_SERVICES = ['basic-1', 'minimal-2', 'basic-2', 'basic-3', 'basic-4']
 

--- a/pybotvac/robot.py
+++ b/pybotvac/robot.py
@@ -4,8 +4,8 @@ import os.path
 import re
 import urllib3
 import requests
-from datetime import datetime
-from babel.dates import format_datetime
+from datetime import datetime, timezone
+from email.utils import format_datetime
 
 from .neato import Neato    # For default Vendor argument
 
@@ -245,9 +245,8 @@ class Auth(requests.auth.AuthBase):
         # We have to format the date according to RFC 2616
         # https://tools.ietf.org/html/rfc2616#section-14.18
 
-        now = datetime.utcnow()
-        format = 'EEE, dd LLL yyyy hh:mm:ss'
-        date = format_datetime(now, format, locale='en') + ' GMT'
+        now = datetime.now(timezone.utc)
+        date = format_datetime(now, True)
 
         try:
             # Attempt to decode request.body (assume bytes received)

--- a/pybotvac/robot.py
+++ b/pybotvac/robot.py
@@ -4,6 +4,7 @@ import os.path
 import re
 import requests
 from datetime import datetime
+from babel.dates import format_datetime
 
 from .neato import Neato    # For default Vendor argument
 
@@ -240,10 +241,12 @@ class Auth(requests.auth.AuthBase):
         self.secret = secret
 
     def __call__(self, request):
-        # Due to https://github.com/stianaske/pybotvac/issues/30
-        # Neato expects and supports authentication header ONLY for en_US
-        dt = datetime.utcnow()
-        date = dt.strftime('%a, %d %b %Y %H:%M:%S GMT')
+        # We have to format the date according to RFC 2616
+        # https://tools.ietf.org/html/rfc2616#section-14.18
+
+        now = datetime.utcnow()
+        format = 'EEE, dd LLL yyyy hh:mm:ss'
+        date = format_datetime(now, format, locale='en') + ' GMT'
 
         try:
             # Attempt to decode request.body (assume bytes received)

--- a/pybotvac/robot.py
+++ b/pybotvac/robot.py
@@ -45,8 +45,7 @@ class Robot:
         self._headers = {'Accept': 'application/vnd.neato.nucleo.v1'}
 
         if self.service_version not in SUPPORTED_SERVICES:
-            raise UnsupportedDevice(
-                "Version " + self.service_version + " of service houseCleaning is not known")
+            raise UnsupportedDevice("Version " + self.service_version + " of service houseCleaning is not known")
 
     def __str__(self):
         return "Name: %s, Serial: %s, Secret: %s Traits: %s" % (self.name, self.serial, self.secret, self.traits)
@@ -76,8 +75,7 @@ class Robot:
 
         # Default to using the persistent map if we support basic-3 or basic-4.
         if category is None:
-            category = 4 if self.service_version in [
-                'basic-3', 'basic-4'] and self.has_persistent_maps else 2
+            category = 4 if self.service_version in ['basic-3', 'basic-4'] and self.has_persistent_maps else 2
 
         if self.service_version == 'basic-1':
             json = {'reqId': "1",
@@ -249,8 +247,7 @@ class Auth(requests.auth.AuthBase):
 
         try:
             # Attempt to decode request.body (assume bytes received)
-            msg = '\n'.join([self.serial.lower(), date,
-                             request.body.decode('utf8')])
+            msg = '\n'.join([self.serial.lower(), date, request.body.decode('utf8')])
         except AttributeError:
             # Decode failed, assume request.body is already type str
             msg = '\n'.join([self.serial.lower(), date, request.body])

--- a/pybotvac/robot.py
+++ b/pybotvac/robot.py
@@ -1,10 +1,9 @@
 import hashlib
 import hmac
-import locale
 import os.path
 import re
 import requests
-import time
+from datetime import datetime
 
 from .neato import Neato    # For default Vendor argument
 
@@ -46,7 +45,8 @@ class Robot:
         self._headers = {'Accept': 'application/vnd.neato.nucleo.v1'}
 
         if self.service_version not in SUPPORTED_SERVICES:
-            raise UnsupportedDevice("Version " + self.service_version + " of service houseCleaning is not known")
+            raise UnsupportedDevice(
+                "Version " + self.service_version + " of service houseCleaning is not known")
 
     def __str__(self):
         return "Name: %s, Serial: %s, Secret: %s Traits: %s" % (self.name, self.serial, self.secret, self.traits)
@@ -76,7 +76,8 @@ class Robot:
 
         # Default to using the persistent map if we support basic-3 or basic-4.
         if category is None:
-            category = 4 if self.service_version in ['basic-3', 'basic-4'] and self.has_persistent_maps else 2
+            category = 4 if self.service_version in [
+                'basic-3', 'basic-4'] and self.has_persistent_maps else 2
 
         if self.service_version == 'basic-1':
             json = {'reqId': "1",
@@ -125,7 +126,7 @@ class Robot:
             return self._message(json)
 
         return response
-        
+
     def start_spot_cleaning(self, spot_width=400, spot_height=400):
         # Spot cleaning if applicable to version
         # spot_width: spot width in cm
@@ -193,19 +194,19 @@ class Robot:
 
     def locate(self):
         return self._message({'reqId': "1", 'cmd': "findMe"})
-    
+
     def get_general_info(self):
         return self._message({'reqId': "1", 'cmd': "getGeneralInfo"})
-    
+
     def get_local_stats(self):
         return self._message({'reqId': "1", 'cmd': "getLocalStats"})
-    
+
     def get_preferences(self):
         return self._message({'reqId': "1", 'cmd': "getPreferences"})
-    
+
     def get_map_boundaries(self, map_id=None):
         return self._message({'reqId': "1", 'cmd': "getMapBoundaries", 'params': {'mapId': map_id}})
-    
+
     def get_robot_info(self):
         return self._message({'reqId': "1", 'cmd': "getRobotInfo"})
 
@@ -243,16 +244,13 @@ class Auth(requests.auth.AuthBase):
     def __call__(self, request):
         # Due to https://github.com/stianaske/pybotvac/issues/30
         # Neato expects and supports authentication header ONLY for en_US
-        saved_locale = locale.getlocale(locale.LC_TIME)
-        locale.setlocale(locale.LC_TIME, 'en_US.utf8')
-        
-        date = time.strftime('%a, %d %b %Y %H:%M:%S', time.gmtime()) + ' GMT'
-
-        locale.setlocale(locale.LC_TIME, saved_locale)
+        dt = datetime.utcnow()
+        date = dt.strftime('%a, %d %b %Y %H:%M:%S GMT')
 
         try:
             # Attempt to decode request.body (assume bytes received)
-            msg = '\n'.join([self.serial.lower(), date, request.body.decode('utf8')])
+            msg = '\n'.join([self.serial.lower(), date,
+                             request.body.decode('utf8')])
         except AttributeError:
             # Decode failed, assume request.body is already type str
             msg = '\n'.join([self.serial.lower(), date, request.body])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+Babel
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-Babel
 urllib3
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Babel
+urllib3
 requests


### PR DESCRIPTION
Closes: #45 

I have already mentioned two different approaches to fixing #45. After some testing this one seems to be more stable. It also looks much cleaner to me.

We want to create a timestamp according to [rfc2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.18). 

The [official documentation](https://developers.neatorobotics.com/api/nucleo) shows an example in ruby:
``` ruby
date = Time.now.utc.strftime("%a, %d %b %Y %H:%M:%S GMT")
# => "Fri, 03 Apr 2015 09:12:31 GMT"
```

The alternative approach using the babel package can be seen here: https://github.com/Santobert/pybotvac/tree/avoid_missing_locale_1