### PR TITLE
Fix robot offline

### DIFF
--- a/pybotvac/account.py
+++ b/pybotvac/account.py
@@ -127,11 +127,9 @@ class Account:
                                        secret=robot['secret_key'],
                                        traits=robot['traits'],
                                        endpoint=robot['nucleo_url']))
-            except requests.exceptions.HTTPError:
+            except NeatoRobotException:
                 print ("Your '{}' robot is offline.".format(robot['name']))
                 continue
-            except requests.exceptions.ConnectionError:
-                raise NeatoRobotException("Unable to add robot")
 
         self.refresh_persistent_maps()
         for robot in self._robots:


### PR DESCRIPTION
We catch a wrong exception in `account.py`. Since we use our own exceptions we can't catch HTTPError and ConnectionError anymore.