### PR TITLE
Add more static code analysis

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,6 +14,7 @@ jobs:
           python-version: "3.8"
           architecture: "x64"
       - run: pip install -r requirements.txt
+      - run: codespell
       - run: black --check .
       - run: isort --check --diff .
       - run: pylint pybotvac

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,4 +15,7 @@ jobs:
           architecture: "x64"
       - run: pip install -r requirements.txt
       - run: black --check .
+      - run: isort --check --diff .
       - run: pylint pybotvac
+      - run: flake8 pybotvac
+      - run: bandit -r pybotvac

--- a/pybotvac/neato.py
+++ b/pybotvac/neato.py
@@ -22,6 +22,6 @@ class Neato(Vendor):
     name = "neato"
     endpoint = "https://beehive.neatocloud.com/"
     auth_endpoint = "https://apps.neatorobotics.com/oauth2/authorize"
-    token_endpoint = "https://beehive.neatocloud.com/oauth2/token"
+    token_endpoint = "https://beehive.neatocloud.com/oauth2/token"  # nosec
     scope = ["public_profile", "control_robots", "maps"]
     cert_path = os.path.join(os.path.dirname(__file__), "cert", "neatocloud.com.crt")

--- a/pybotvac/robot.py
+++ b/pybotvac/robot.py
@@ -51,7 +51,7 @@ class Robot:
 
         # pylint: disable=anomalous-backslash-in-string
         self._url = "{endpoint}/vendors/{vendor_name}/robots/{serial}/messages".format(
-            endpoint=re.sub(":\d+", "", endpoint),  # Remove port number
+            endpoint=re.sub(":\d+", "", endpoint),  # noqa: W605, Remove port number
             vendor_name=vendor.name,
             serial=self.serial,
         )

--- a/pybotvac/vorwerk.py
+++ b/pybotvac/vorwerk.py
@@ -5,7 +5,7 @@ class Vorwerk(Vendor):
     name = "vorwerk"
     endpoint = "https://beehive.ksecosys.com/"
     passwordless_endpoint = "https://mykobold.eu.auth0.com/passwordless/start"
-    token_endpoint = "https://mykobold.eu.auth0.com/oauth/token"
+    token_endpoint = "https://mykobold.eu.auth0.com/oauth/token"  # nosec
     scope = ["openid", "email", "profile", "read:current_user"]
     audience = "https://mykobold.eu.auth0.com/userinfo"
     source = "vorwerk_auth0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pylint>=2.6
 flake8>=3
 isort>=5
 bandit>=1
+codespell>=2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 urllib3
 requests
 requests_oauthlib
+bandit>=1
 black
-pylint>=2.6
+codespell>=2
 flake8>=3
 isort>=5
-bandit>=1
-codespell>=2
+pylint>=2.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,7 @@ urllib3
 requests
 requests_oauthlib
 black
-pylint
+pylint>=2.6
+flake8>=3
+isort>=5
+bandit>=1

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,3 +14,6 @@ ignore =
     E501,
     W503,
     W504,
+
+[codespell]
+skip = ./.git,./.mypy_cache,./.vscode,./venv

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,16 @@
+[isort]
+profile=black
+multi_line_output = 3
+src_paths=pybotvac, sample
+
+[flake8]
+exclude = .vscode,venv
+max-line-length = 88
+ignore =
+    F401,  # Import error, pylint covers this
+    # Formatting errors that are covered by black
+    D202,
+    E203,
+    E501,
+    W503,
+    W504,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,5 @@
-[isort]
-profile=black
-multi_line_output = 3
-src_paths=pybotvac, sample
+[codespell]
+skip = ./.git,./.mypy_cache,./.vscode,./venv
 
 [flake8]
 exclude = .vscode,venv
@@ -15,5 +13,7 @@ ignore =
     W503,
     W504,
 
-[codespell]
-skip = ./.git,./.mypy_cache,./.vscode,./venv
+[isort]
+profile=black
+multi_line_output = 3
+src_paths=pybotvac, sample


### PR DESCRIPTION
This PR adds codespell, isort, flake8 and bandit:

- codespell finds spelling errors
- isort sorts imports based on their category 'STDLIB', 'THIRDPARTY', 'FIRSTPARTY', ...
- flake8 is a linter that covers some things not handled by pylint
- bandit looks for security issues

@stianaske please be honest. If you don't want your contributors to be bothered by these tools, I will remove them again. But I personally like the support provided by these utilities. I run them in my development environment anyway and would be happy to have a CI automate that for me