### PR TITLE
Fix persistent maps attribute

### DIFF
--- a/pybotvac/account.py
+++ b/pybotvac/account.py
@@ -221,6 +221,8 @@ class Account:
             if ("persistent_maps" in robot.traits
                     and len(self._persistent_maps.get(robot.serial, [])) > 0):
                 robot.has_persistent_maps = True
+            else:
+                robot.has_persistent_maps = False
 
     @staticmethod
     def get_map_image(url, dest_path=None, file_name=None):

--- a/pybotvac/account.py
+++ b/pybotvac/account.py
@@ -218,7 +218,9 @@ class Account:
 
         self.refresh_persistent_maps()
         for robot in self._robots:
-            robot.has_persistent_maps = robot.serial in self._persistent_maps
+            if ("persistent_maps" in robot.traits
+                    and len(self._persistent_maps.get(robot.serial, [])) > 0):
+                robot.has_persistent_maps = True
 
     @staticmethod
     def get_map_image(url, dest_path=None, file_name=None):


### PR DESCRIPTION
Just looking for a key in a dict, which will always be there, isn't sufficient to determine whether a robot has persistent maps or not. The persistent maps endpoint seem to return empty lists if a robot doesn't have maps, and also the string persistent_maps as a trait. Look for these to determine whether a robot has persistent maps or not.

I have a D5 and a D7 which I recently rearranged and removed the persistent maps from, which caused the `robot.start_cleaning()` to break. I figured that it was because of the automatic category selection going wrong because of the robot.has_persistent_maps always being true. The account.persistent_maps dict looked like this:

```python
{'OPS00000-E8EB00000CC4': [], 'GPC00000-24762500000E': []}
```

I created a new persistent map for the D7 today, and now the above dict looks like: 

```python
{'OPS00000-E8EB00000CC4': [],
'GPC00000-24762500000E': [{'id': '2021-11-20T07:30:36Z',
'name': 'Floor 1',
'url': 'https://neatorobotics.s3.amazonaws.com/persistent-maps/GPC00000-24762500000E/2021-11-20T07:30:36Z/b80000002b5db244e0fb/user-map.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AAAAAAAAAAAAAAAA%2F20211120%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20211120T124208Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=408f4e6b47544425bada4b2d272261703a28eec61762f8d061f622354528e000',
'raw_floor_map_url': 'https://neatorobotics.s3.amazonaws.com/persistent-maps/GPC00000-24762500000E/2021-11-20T07:30:36Z/b80000002b5db244e0fb/floor-map.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AAAAAAAAAAAAAAAA%2F20211120%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20211120T124208Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=a165d5263b3fb0000001586e51f49e9784727204d06db8aa5d9c443bb7c1e000',
'url_valid_for_seconds': 300}]}
```

I also noted that the `traits` list includes the `persistent_maps` if a map exists for the robot:

D7 with map:
```python
{'serial': 'GPC00000-24762500000E',
'prefix': None,
'name': 'John V',
'model': 'BotVacD7Connected',
'firmware': '4.6.0-72',
'timezone': 'Europe/Stockholm',
'secret_key': '39',
'purchased_at': None,
'linked_at': '2021-11-12T13:57:19Z',
'nucleo_url': 'https://nucleo.neatocloud.com:4443',
'traits': ['maps', 'persistent_maps'],
'proof_of_purchase_url': None,
'proof_of_purchase_url_valid_for_seconds': 900,
'proof_of_purchase_generated_at': None,
'mac_address': '24762500000e',
'created_at': '2021-11-12T13:57:19Z'}
```

D5 w/o map:
```python
{'serial': 'OPS00000-E8EB00000CC4',
'prefix': 'SN',
'name': 'John',
'model': 'BotVacD5Connected',
'firmware': '4.5.3-189',
'timezone': 'Europe/Stockholm',
'secret_key': '43',
'purchased_at': None,
'linked_at': '2018-10-13T18:41:04Z',
'nucleo_url': 'https://nucleo.neatocloud.com:4443',
'traits': ['maps'],
'proof_of_purchase_url': None,
'proof_of_purchase_url_valid_for_seconds': 900,
'proof_of_purchase_generated_at': None,
'mac_address': 'e8eb00000cc4',
'created_at': '2018-07-20T17:23:13Z'}
```

With this PR, the `robot.start_cleaning()` sends this:

D7 with map:
```
DEBUG:pybotvac.robot:Send https://nucleo.neatocloud.com/vendors/neato/robots/GPC00000-200000000000/messages {'reqId': '1',
'cmd': 'startCleaning',
'params': {'category': 4,
'mode': 2,
'modifier': 1,
'navigationMode': 1}}
```

D5 w/o map:
```
DEBUG:pybotvac.robot:Send https://nucleo.neatocloud.com/vendors/neato/robots/OPS00000-E00000000000/messages {'reqId': '1',
'cmd': 'startCleaning',
'params': {'category': 2,
'mode': 2,
'modifier': 1,
'navigationMode': 1}}
```