### PR TITLE
Fix invalid escape sequence DeprecationWarning

### DIFF
--- a/pybotvac/robot.py
+++ b/pybotvac/robot.py
@@ -138,7 +138,7 @@ class Robot:
 
         # pylint: disable=anomalous-backslash-in-string
         self._url = "{endpoint}/vendors/{vendor_name}/robots/{serial}/messages".format(
-            endpoint=re.sub(":\d+", "", endpoint),  # noqa: W605, Remove port number
+            endpoint=re.sub(r":\d+", "", endpoint),  # Remove port number
             vendor_name=vendor.name,
             serial=self.serial,
         )

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,8 @@ skip = ./.git,./.mypy_cache,./.vscode,./venv
 exclude = .vscode,venv
 max-line-length = 88
 ignore =
-    F401,  # Import error, pylint covers this
+    # Import error, pylint covers this
+    F401,
     # Formatting errors that are covered by black
     D202,
     E203,


### PR DESCRIPTION
```
  /.../pybotvac/robot.py:141: DeprecationWarning: invalid escape sequence '\d'
    endpoint=re.sub(":\d+", "", endpoint),  # noqa: W605, Remove port number
```