### PR TITLE
Replace deprected pk_reources with importlib.metadata

### DIFF
--- a/pybotvac/version.py
+++ b/pybotvac/version.py
@@ -1,6 +1,27 @@
-import pkg_resources
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    # During type checking, we assume the standard library interface is available
+    from importlib.metadata import PackageNotFoundError, version
+else:
+    # At runtime, use stdlib importlib.metadata if available, otherwise fall back
+    try:
+        from importlib.metadata import PackageNotFoundError, version
+    except ImportError:
+        try:
+            from importlib_metadata import PackageNotFoundError, version  # backport
+        except ImportError:
+            # Final fallback: provide minimal stubs
+            class PackageNotFoundError(Exception):
+                """Fallback exception used when metadata backends are unavailable."""
+                pass
+
+            def version(_dist_name: str) -> str:
+                """Fallback version() that always raises PackageNotFoundError."""
+                raise PackageNotFoundError(f"Package '{_dist_name}' not found")
+
 
 try:
-    __version__ = pkg_resources.get_distribution("pybotvac").version
-except Exception:  # pylint: disable=broad-except
+    __version__ = version("pybotvac")
+except PackageNotFoundError:  # pragma: no cover - environment dependent
     __version__ = "unknown"

--- a/pybotvac/version.py
+++ b/pybotvac/version.py
@@ -1,6 +1,5 @@
 from importlib.metadata import PackageNotFoundError, version
 
-
 try:
     __version__ = version("pybotvac")
 except PackageNotFoundError:  # pragma: no cover - environment dependent

--- a/pybotvac/version.py
+++ b/pybotvac/version.py
@@ -1,24 +1,4 @@
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    # During type checking, we assume the standard library interface is available
-    from importlib.metadata import PackageNotFoundError, version
-else:
-    # At runtime, use stdlib importlib.metadata if available, otherwise fall back
-    try:
-        from importlib.metadata import PackageNotFoundError, version
-    except ImportError:
-        try:
-            from importlib_metadata import PackageNotFoundError, version  # backport
-        except ImportError:
-            # Final fallback: provide minimal stubs
-            class PackageNotFoundError(Exception):
-                """Fallback exception used when metadata backends are unavailable."""
-                pass
-
-            def version(_dist_name: str) -> str:
-                """Fallback version() that always raises PackageNotFoundError."""
-                raise PackageNotFoundError(f"Package '{_dist_name}' not found")
+from importlib.metadata import PackageNotFoundError, version
 
 
 try:


### PR DESCRIPTION
I use a fork of the homeassistant-vorwerk custom integration in Home Assistant which uses pybotvac as a dependency and noticed this warning in the logs:

> /usr/local/lib/python3.13/site-packages/pybotvac/version.py:1: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81. import pkg_resources

These changes should fix the problem.